### PR TITLE
API validation on request URL

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -41,7 +41,7 @@ func (s *ActionsService) List(ctx context.Context, opts *ActionsListOptions) (*A
 //
 // API docs: https://api-docs.incident.io/#operation/Actions_Show
 func (s *ActionsService) Get(ctx context.Context, id string) (*ActionResponse, *Response, error) {
-	u := fmt.Sprintf("actions/%s", id)
+	u := fmt.Sprintf("v2/actions/%s", id)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/custom_fields.go
+++ b/custom_fields.go
@@ -37,7 +37,7 @@ func (s *CustomFieldsService) List(ctx context.Context) (*CustomFieldsList, *Res
 //
 // API docs: https://api-docs.incident.io/#operation/Custom%20Fields_Show
 func (s *CustomFieldsService) Get(ctx context.Context, id string) (*CustomFieldResponse, *Response, error) {
-	u := fmt.Sprintf("custom_fields/%s", id)
+	u := fmt.Sprintf("v2/custom_fields/%s", id)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/incident.go
+++ b/incident.go
@@ -20,8 +20,7 @@ import (
 const (
 	// API URL
 	//Adding two versions since some endpoints are only available in v1
-	apiURLv1 = "https://api.incident.io/v1/"
-	apiURLv2 = "https://api.incident.io/v2/"
+	apiURL = "https://api.incident.io/"
 
 	// User Agent that will be used for HTTP requests.
 	// Should help to identify the source of the calls in case of emergency.
@@ -67,20 +66,12 @@ type service struct {
 // NewClient returns a new Incident.io API client.
 // All endpoints require authentication, the apiKey should be set.
 // If a nil httpClient is provided, a new http.Client will be used.
-func NewClient(apiKey string, apiVersion string, httpClient *http.Client) *Client {
+func NewClient(apiKey string, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	// validate apiVersion since certain endpoints are only available in v1
-	var baseURL *url.URL
-	if apiVersion == "v1" {
-		baseURL, _ = url.Parse(apiURLv1)
-	} else if apiVersion == "v2" {
-		baseURL, _ = url.Parse(apiURLv2)
-	} else {
-		// Default to v2
-		baseURL, _ = url.Parse(apiURLv2)
-	}
+	// baseURL does not include API version since some endpoints are only available in v1. Will be added in request URL instead.
+	baseURL, _ := url.Parse(apiURL)
 
 	c := &Client{
 		client:    httpClient,

--- a/incident_roles.go
+++ b/incident_roles.go
@@ -37,7 +37,7 @@ func (s *IncidentRolesService) List(ctx context.Context) (*IncidentRolesList, *R
 //
 // API docs: https://api-docs.incident.io/#operation/Incident%20Roles_Show
 func (s *IncidentRolesService) Get(ctx context.Context, id string) (*IncidentRoleResponse, *Response, error) {
-	u := fmt.Sprintf("incident_roles/%s", id)
+	u := fmt.Sprintf("v2/incident_roles/%s", id)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/incidents.go
+++ b/incidents.go
@@ -41,7 +41,7 @@ func (s *IncidentsService) List(ctx context.Context, opts *IncidentsListOptions)
 //
 // API docs: https://api-docs.incident.io/#operation/Incidents_Show
 func (s *IncidentsService) Get(ctx context.Context, id string) (*IncidentResponse, *Response, error) {
-	u := fmt.Sprintf("incidents/%s", id)
+	u := fmt.Sprintf("v2/incidents/%s", id)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/severities.go
+++ b/severities.go
@@ -37,7 +37,7 @@ func (s *SeveritiesService) List(ctx context.Context) (*SeveritiesList, *Respons
 //
 // API docs: https://api-docs.incident.io/#operation/Severities_Show
 func (s *SeveritiesService) Get(ctx context.Context, id string) (*SeverityResponse, *Response, error) {
-	u := fmt.Sprintf("severities/%s", id)
+	u := fmt.Sprintf("v1/severities/%s", id)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {


### PR DESCRIPTION
Removed API validation from main function and instead changed the baseURL to not include API version.

We can change the Request URLs to use the desired API version.
- Severities only supports V1, so the request has been changed to V1. 
- All other requests have a V2 version so we use it. 